### PR TITLE
Add support for alternative names

### DIFF
--- a/letsencrypt_service
+++ b/letsencrypt_service
@@ -34,6 +34,7 @@ update_certs() {
         echo "Creating/renewal $base_domain certificates... (${hosts_array_expanded[*]})"
         /usr/local/bin/simp_le \
              $params_d_str \
+             -f account_key.json \
              -f fullchain.pem -f key.pem \
              --email "${!email_varname}" \
              --server=https://acme-v01.api.letsencrypt.org/directory \

--- a/letsencrypt_service
+++ b/letsencrypt_service
@@ -18,29 +18,37 @@ update_certs() {
         hosts_array=$host_varname[@]
         email_varname="LETSENCRYPT_${cid}_EMAIL"
 
+        params_d_str=""
+        hosts_array_expanded=("${!hosts_array}")
+        # First domain will be our base domain
+        base_domain="${hosts_array_expanded[0]}"
+
+        # Create directorty for the first domain
+        mkdir -p /etc/nginx/certs/$base_domain
+        cd /etc/nginx/certs/$base_domain
+
         for domain in "${!hosts_array}"; do
-
-            # Create the domain directory
-            mkdir -p /etc/nginx/certs/$domain
-            cd /etc/nginx/certs/$domain
-
-            echo "Creating/renewal $domain certificates..."
-            /usr/local/bin/simp_le \
-             -d "$domain" \
+            # Add all the domains to certificate
+            params_d_str+=" -d $domain"
+        done
+        echo "Creating/renewal $base_domain certificates... (${hosts_array_expanded[*]})"
+        /usr/local/bin/simp_le \
+             $params_d_str \
              -f fullchain.pem -f key.pem \
              --email "${!email_varname}" \
              --server=https://acme-v01.api.letsencrypt.org/directory \
              --default_root /usr/share/nginx/html/
 
-            simp_le_return=$?
+        simp_le_return=$?
 
-            if [[ $simp_le_return -eq 0 ]]; then
-                # Symlink to created certificate and key.
-                ln -sf ./$domain/fullchain.pem /etc/nginx/certs/$domain".crt"
-                ln -sf ./$domain/key.pem       /etc/nginx/certs/$domain".key"
-                reload_nginx='true'
-            fi
-        done
+        if [[ $simp_le_return -eq 0 ]]; then
+            for domain in "${!hosts_array}"; do
+                # Symlink all alternative names to base domain certificate
+                ln -sf ./$base_domain/fullchain.pem /etc/nginx/certs/$domain".crt"
+                ln -sf ./$base_domain/key.pem       /etc/nginx/certs/$domain".key"
+            done
+            reload_nginx='true'
+        fi
     done
     unset LETSENCRYPT_CONTAINERS
     if [[ "$reload_nginx" == 'true' ]]; then


### PR DESCRIPTION
This adds support for alternative names in certificate as discussed in #12.

The first domain in the list becomes base domain. All other domains added to "Alternative Name" field of certificate. Alternative names are symlinked to a base domain certificate.
