### PR TITLE
eliminate confusion in example of Let's Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,10 @@ The `LETSENCRYPT_HOST` variable most likely needs to be the same as the `VIRTUAL
 For example
 
 ```
-$ docker run -d -p 80:80 -p 443:443 \
+$ docker run -d -p 80:80 \
     -e VIRTUAL_HOST="foo.bar.com,bar.com" \
     -e LETSENCRYPT_HOST="foo.bar.com,bar.com" \
-    -e LETSENCRYPT_EMAIL="foo@bar.com" \
-    -v /var/run/docker.sock:/tmp/docker.sock:ro \
-    dmp1ce/nginx-proxy-letsencrypt
+    -e LETSENCRYPT_EMAIL="foo@bar.com" ...
 ```
 
 ### Basic Authentication Support


### PR DESCRIPTION
We don't need a connection over a proxy to a proxy.
