### PR TITLE
CA server url as env parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ $ docker run -d -p 80:80 \
     -e LETSENCRYPT_EMAIL="foo@bar.com" ...
 ```
 
+##### Optional container environment variables
+
+Optional nginx-proxy-letsencrypt container environment variables for custom configuration.
+
+- `ACME_CA_URI` - Directory URI for the CA ACME API endpoint (default: ``https://acme-v01.api.letsencrypt.org/directory``)
+
+For example
+
+```
+$ docker run -d -p 80:80 -p 443:443 \
+    -e ACME_CA_URI="https://acme-staging.api.letsencrypt.org/directory" \
+    -v /path/to/certs:/etc/nginx/certs \
+    -v /var/run/docker.sock:/tmp/docker.sock:ro \
+    dmp1ce/nginx-proxy-letsencrypt
+```
+
 ### Basic Authentication Support
 
 In order to be able to secure your virtual host, you have to create a file named as its equivalent VIRTUAL_HOST variable on directory

--- a/letsencrypt_service
+++ b/letsencrypt_service
@@ -3,6 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 seconds_to_wait=3600
+acme_ca_uri="${ACME_CA_URI:-https://acme-v01.api.letsencrypt.org/directory}"
 
 update_certs() {
     [[ ! -f "$DIR"/letsencrypt_service_data ]] && return
@@ -36,7 +37,7 @@ update_certs() {
              -f account_key.json -f key.pem -f fullchain.pem \
              $params_d_str \
              --email "${!email_varname}" \
-             --server=https://acme-v01.api.letsencrypt.org/directory \
+             --server=$acme_ca_uri \
              --default_root /usr/share/nginx/html/
 
         simp_le_return=$?


### PR DESCRIPTION
Letsencrypt authority have multiple servers, so it is a good idea to have way to set up non default server url.

During the beta phase, Let's Encrypt enforces strict rate limits on the number of certificates issued for one domain, but it is possible to use staging server (https://acme-staging.api.letsencrypt.org/directory) to avoid those limits (of course staging certificate is not valid).
